### PR TITLE
Fix for #29 ConcurrentModificationException

### DIFF
--- a/src/main/java/com/radiusnetworks/ibeacon/service/IBeaconService.java
+++ b/src/main/java/com/radiusnetworks/ibeacon/service/IBeaconService.java
@@ -531,7 +531,9 @@ public class IBeaconService extends Service {
             if (IBeaconManager.LOG_DEBUG)
                 Log.d(TAG, "Calling ranging callback with " + rangeState.getIBeacons().size() + " iBeacons");
             rangeState.getCallback().call(IBeaconService.this, "rangingData", new RangingData(rangeState.getIBeacons(), region));
-            rangeState.clearIBeacons();
+            synchronized (rangeState) {
+            	rangeState.clearIBeacons();
+			}
         }
 
     }
@@ -590,7 +592,9 @@ public class IBeaconService extends Service {
             Region region = matchedRegionIterator.next();
             if (IBeaconManager.LOG_DEBUG) Log.d(TAG, "matches ranging region: " + region);
             RangeState rangeState = rangedRegionState.get(region);
-            rangeState.addIBeacon(iBeacon);
+            synchronized (rangeState) {
+            	rangeState.addIBeacon(iBeacon);
+			}
         }
     }
 

--- a/src/main/java/com/radiusnetworks/ibeacon/service/RangeState.java
+++ b/src/main/java/com/radiusnetworks/ibeacon/service/RangeState.java
@@ -41,13 +41,17 @@ public class RangeState {
 		return callback;
 	}
 	public void clearIBeacons() {
-		iBeacons.clear();
+		synchronized (iBeacons) {
+			iBeacons.clear();
+		}
 	}
 	public Set<IBeacon> getIBeacons() {
 		return iBeacons;
 	}
 	public void addIBeacon(IBeacon iBeacon) {
-		iBeacons.add(iBeacon);
+		synchronized (iBeacons) {
+			iBeacons.add(iBeacon);
+		}
 	}
 	
 

--- a/src/main/java/com/radiusnetworks/ibeacon/service/RangingData.java
+++ b/src/main/java/com/radiusnetworks/ibeacon/service/RangingData.java
@@ -39,7 +39,9 @@ public class RangingData implements Parcelable {
 	private RegionData regionData;
 
 	public RangingData (Collection<IBeacon> iBeacons, Region region) {
-		this.iBeaconDatas =  IBeaconData.fromIBeacons(iBeacons);
+		synchronized (iBeacons) {
+			this.iBeaconDatas =  IBeaconData.fromIBeacons(iBeacons);
+		}
 		this.regionData = new RegionData(region);
 	}
 


### PR DESCRIPTION
Synchronized rangeState object in the service to avoid modification by
AsyncTask while iterating over iBeacons.

ps:This happens rarely so it's hard to reproduce but I suspect the between scan period falls short when too many beacons are advertising, scan cycle is ended prematurely in those cases which results with ConcurrentModificationException on iBeacon collection via the rangeState object reference. While processRangeData() is trying to clear the iBeacon colllection, processIBeaconFromScan() is called from ScanProcessor()'s AsyncTask to add the beacon into the same collection. This update should fix it, tested for longer than 24h with ~50 beacons and 5 second between scan period without any exceptions. I suspect the excessive synchronization of iBeacon object is redundant but this is the safe setup I have tested with so far. Needs confirmation.
