### PR TITLE
Update IBeaconManager.java documentation

### DIFF
--- a/src/main/java/com/radiusnetworks/ibeacon/IBeaconManager.java
+++ b/src/main/java/com/radiusnetworks/ibeacon/IBeaconManager.java
@@ -191,11 +191,11 @@ public class IBeaconManager {
 	}
 	/**
 	 * Check if Bluetooth LE is supported by this Android device, and if so, make sure it is enabled.
-	 * Throws a BleNotAvailableException if Bluetooth LE is not supported.  (Note: The Android emulator will do this)
+	 * @throws  BleNotAvailableException if Bluetooth LE is not supported.  (Note: The Android emulator will do this)
 	 * @return false if it is supported and not enabled
 	 */
     @TargetApi(18)
-	public boolean checkAvailability() {
+	public boolean checkAvailability() throws BleNotAvailableException {
         if (android.os.Build.VERSION.SDK_INT < 18) {
             throw new BleNotAvailableException("Bluetooth LE not supported by this device");
         }


### PR DESCRIPTION
_checkAvailability()_ method throws _BleNotAvailableException_, but it's **not** declared.
This is described in Javadoc comment to this method, but with "Throws" instead of "@throws".

fixed
